### PR TITLE
fix erreur on windows

### DIFF
--- a/src/Module/ComposeModule.js
+++ b/src/Module/ComposeModule.js
@@ -166,7 +166,7 @@ function execDockerComposeCommandByContainer(command, container, options = [], r
         Output.info("Try to use 'skyflow compose:update'", false);
         process.exit(1)
     }
-    if (_.indexOf(Shell.getArrayResult(), container) === -1) {
+    if (_.indexOf(Shell.getArrayResult(), container) === -1 && _.indexOf(Shell.getArrayResult(), container+'\r') === -1) {
         Output.error("Service " + container + " not found in docker-compose.yml file.", false);
         process.exit(1)
     }


### PR DESCRIPTION
Fixes #12 

Bon alors ce que j'ai trouver en rapport avec l'issue N°12 que j'ai ouvert c'est que : 

![fix_windows_run_command_1](https://user-images.githubusercontent.com/13063865/48847848-d642ff80-eda2-11e8-9bcb-9a8e701bd49b.png)

la fonction run de la class Shell remplis la variable "this.arrayResult"  avec un tableau qui liste les noms des conteneurs.

Mais (je sais pas pourquoi) sur windows les nom de conteneur se voient ajouter '\r' à la fin. (voir photo).

Dans la fonction execDockerComposeCommandByContainer on test le nom du conteneur avec un indexOf pour savoir s'il existe mais en l'occurence le nom n'est pas le même car il contient un '\r' donc ça renvois une érreur. 

J'ai fait un petit fix (pas trés propre car il ne corrige pas la source du problème) 
mais qui fait l'affaire et permet au gens sur windows de faire fonctionner la commande compose:run 
